### PR TITLE
 [NIFI-7470] Change _source_include to _source_includes

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractElasticsearchHttpProcessor.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractElasticsearchHttpProcessor.java
@@ -67,7 +67,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractElasticsearchHttpProcessor extends AbstractElasticsearchProcessor {
 
-    static final String FIELD_INCLUDE_QUERY_PARAM = "_source_include";
+    static final String FIELD_INCLUDE_QUERY_PARAM = "_source_includes";
     static final String QUERY_QUERY_PARAM = "q";
     static final String SORT_QUERY_PARAM = "sort";
     static final String SIZE_QUERY_PARAM = "size";


### PR DESCRIPTION
Change "_source_include" to "_source_includes" in response to [NIFI-7470], so that queries work.

Enables using the Fields functionality in elasticsearch queries. fixes bug NIFI-7470.

Adds an 's' character to the String FIELD_INCLUDE_QUERY_PARAM so that it won't break the queries when using Fields in ElasticSearch HTTP processors.


